### PR TITLE
Add /competitors route

### DIFF
--- a/chatmeter.gemspec
+++ b/chatmeter.gemspec
@@ -6,7 +6,7 @@ require "chatmeter/version"
 Gem::Specification.new do |spec|
   spec.name          = "chatmeter"
   spec.version       = Chatmeter::VERSION
-  spec.authors       = ["Levi Brown", "Kyle Rose", "Pablo Rodriguez"]
+  spec.authors       = ["Levi Brown", "Kyle Rose", "Pablo Rodriguez", "Kirk Stennett"]
   spec.email         = ["levi.brown@getg5.com"]
 
   spec.summary       = %q{A ruby wrapper for the chatmeter API.}

--- a/lib/chatmeter/api.rb
+++ b/lib/chatmeter/api.rb
@@ -18,6 +18,7 @@ require "chatmeter/api/user_group_access"
 require "chatmeter/api/user_location_access"
 require "chatmeter/api/login"
 require "chatmeter/api/campaign"
+require "chatmeter/api/competitors"
 require "chatmeter/api/mock"
 require "chatmeter/api/errors"
 
@@ -73,7 +74,7 @@ module Chatmeter
         reerror.set_backtrace(error.backtrace)
         raise(reerror)
       end
-      
+
       if response.body && !response.body.empty?
         begin
           response.body = MultiJson.load(response.body, symbolize_keys: true)

--- a/lib/chatmeter/api/competitors.rb
+++ b/lib/chatmeter/api/competitors.rb
@@ -1,0 +1,15 @@
+module Chatmeter
+  class API
+
+    # GET /competitors
+    def competitors(params)
+      request(
+        expects: 200,
+        method:  :post,
+        path:    "/competitors",
+        body:    params.to_json
+      )
+    end
+
+  end
+end

--- a/lib/chatmeter/api/mock.rb
+++ b/lib/chatmeter/api/mock.rb
@@ -8,6 +8,7 @@ require 'chatmeter/api/mock/location'
 require 'chatmeter/api/mock/review'
 require 'chatmeter/api/mock/account'
 require 'chatmeter/api/mock/campaign'
+require 'chatmeter/api/mock/competitors'
 
 module Chatmeter
   class API

--- a/lib/chatmeter/api/mock/competitors.rb
+++ b/lib/chatmeter/api/mock/competitors.rb
@@ -1,0 +1,48 @@
+module Chatmeter
+  class API
+    module Mock
+
+      # stub POST /competitors
+			Excon.stub(expects: 200, method: :post, path: '/v5/competitors') do |params|
+        {
+          body: [
+            {
+              "locationId": "26794",
+              "competitorName": "Auto Detailing By Ron Thompson",
+              "competitorId": "1128900",
+              "providerListingUrls": {
+                "GOOGLE": "https://maps.google.com/?cid=11793612764198950331",
+                "YELP": "http://www.yelp.com/biz/auto-detailing-by-ron-thompson-portland"
+              },
+              "competitorAddress":"Auto Detailing By Ron Thompson, 34 Grosvenor Square, London, Engla, W1K 2HD, GB",
+              "competitorPhone":"02033503434"
+            },
+            {
+              "locationId": "26794",
+              "competitorName": "Auto Detailing By Ron Thompson Llc.",
+              "competitorId": "1060520",
+              "providerListingUrls": {
+                "GOOGLE": "https://maps.google.com/?cid=11793612764198950331",
+                "YELP": "http://www.yelp.com/biz/auto-detailing-by-ron-thompson-portland"
+              },
+              "competitorAddress":"Auto Detailing By Ron Thompson Llc., 12 Upper St Martin's Lane, London, Engla, WC2H 9FB, GB",
+              "competitorPhone":"02074209320"
+            },
+            {
+              "locationId": "26794",
+              "competitorName": "Alpha's Auto Detail",
+              "competitorId": "523196",
+              "providerListingUrls": {
+                "GOOGLE": "https://maps.google.com/?cid=17654320774046061809",
+                "YELP": "http://www.yelp.com/biz/alphas-auto-detail-portland"
+              },
+              "competitorAddress":"Alpha's Auto Detail, 2028 Hancock Street, San Diego, CA, 92110, US",
+              "competitorPhone":"6192949590"
+            }
+          ],
+          status: 200
+        }
+      end
+    end
+  end
+end

--- a/lib/chatmeter/version.rb
+++ b/lib/chatmeter/version.rb
@@ -1,3 +1,3 @@
 module Chatmeter
-  VERSION = "1.1.8"
+  VERSION = "1.2.0"
 end

--- a/spec/chatmeter/api/competitor_spec.rb
+++ b/spec/chatmeter/api/competitor_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Chatmeter::API do
+
+  context "Campaigns endpoint" do
+    let(:chatmeter) { Chatmeter::API.new(username: '123456@example.com', password: 'pw12345', mock: true) }
+    let(:params) { { locationIds: ["26794"], providers: ["YELP", "GOOGLE"] } }
+
+		it "should return valid response for #competitors" do
+			competitors = chatmeter.competitors(params)
+      expect(competitors).to be_instance_of(Array)
+      expect(competitors[0][:providerListingUrls]).to have_key(:GOOGLE)
+      expect(competitors[0][:providerListingUrls]).to have_key(:YELP)
+      expect(competitors[0]).to have_key(:competitorPhone)
+      expect(competitors[0]).to have_key(:competitorAddress)
+    end
+
+  end
+end


### PR DESCRIPTION
This PR adds the `/competitors` endpoint for the Chatmeter API. Following specs listed in the API v5 on: http://newapi.chatmeter.com/#get-competitor-data