### PR TITLE
Add Listings path to Chatmeter

### DIFF
--- a/lib/chatmeter/api.rb
+++ b/lib/chatmeter/api.rb
@@ -19,6 +19,7 @@ require "chatmeter/api/user_location_access"
 require "chatmeter/api/login"
 require "chatmeter/api/campaign"
 require "chatmeter/api/competitors"
+require "chatmeter/api/listings"
 require "chatmeter/api/mock"
 require "chatmeter/api/errors"
 

--- a/lib/chatmeter/api/listings.rb
+++ b/lib/chatmeter/api/listings.rb
@@ -1,0 +1,17 @@
+require 'uri'
+
+module Chatmeter
+  class API
+
+    # GET /listings
+    def get_listings(params={})
+      request(
+        expects: 200,
+        method:  :get,
+        path:    "/listings",
+        query:   params
+      )
+    end
+
+  end
+end

--- a/lib/chatmeter/api/mock.rb
+++ b/lib/chatmeter/api/mock.rb
@@ -9,6 +9,7 @@ require 'chatmeter/api/mock/review'
 require 'chatmeter/api/mock/account'
 require 'chatmeter/api/mock/campaign'
 require 'chatmeter/api/mock/competitors'
+require 'chatmeter/api/mock/listings'
 
 module Chatmeter
   class API

--- a/lib/chatmeter/api/mock/listings.rb
+++ b/lib/chatmeter/api/mock/listings.rb
@@ -1,0 +1,98 @@
+module Chatmeter
+  class API
+    module Mock
+
+      # stub GET /reviewBuilder/campaign/get
+			Excon.stub(expects: 200, method: :get, path: '/v5/listings') do |params|
+        request_params, mock_data = parse_stub_params(params)
+        {
+          body: {
+            "listings":[
+              {
+                "id": "24343434",
+                "locationId": "22121",
+                "contentProvider": "GOOGLE",
+                "listingType": "Best",
+                "listingURL": "https://maps.google.com/?cid=6534117673332158777",
+                "expected": {
+                  "businessName": "Coffee Shop 2",
+                  "website": "http://www.mycoffeeshop.com",
+                  "address": {
+                    "street": "234 Main Street",
+                    "city": "San Diego",
+                    "postalCode": "92101",
+                    "state": "CA",
+                    "country": "USA"
+                  },
+                  "phoneNumber": "5555551234"
+                },
+                "found": {
+                  "businessName": "Coffee Shop",
+                  "website": "http://www.mycoffeeshop.com",
+                  "address": {
+                    "street": "234 Main Street",
+                    "city": "San Diego",
+                    "postalCode": "92101",
+                    "state": "AZ",
+                    "country": "USA"
+                  },
+                  "phoneNumber": "5555550000"
+                },
+                "matchErrors": [
+                  "BusinessName",
+                  "PhoneNumber",
+                  "State"
+                ],
+                "listingInfo": {
+                  "claimStatus": {
+                    "claimed": false
+                  },
+                  "categories": [
+                    "Coffee Shop",
+                    "Cafe"
+                  ],
+                  "photoURLs": [
+                    "https://plus.google/232323/23.png"
+                  ],
+                  "stats": {
+                    "categories": 2,
+                    "photos": 1,
+                    "videos": 0,
+                    "averageRating": 2.5,
+                    "reviewCount": 10
+                  }
+                },
+                "dateAdded": "2014-02-09T01:20:38Z",
+                "lastUpdated": "2015-03-05T12:44:38Z"
+              },
+              {
+                "locationId": "22121",
+                "contentProvider": "BING",
+                "listingType": "Missing",
+                "expected": {
+                  "businessName": "Coffee Shop 2",
+                  "website": "http://www.mycoffeeshop.com",
+                  "address": {
+                    "street": "234 Main Street",
+                    "city": "San Diego",
+                    "postalCode": "92101",
+                    "state": "CA",
+                    "country": "USA"
+                  },
+                  "phoneNumber": "5555551234"
+                },
+                "found": {
+                },
+                "dateAdded": "2014-02-09T01:20:38Z",
+                "lastUpdated": "2015-03-05T12:44:38Z"
+              }
+            ],
+            "hasMore": false
+          },
+          status: 200
+        }
+      end
+
+    end
+  end
+end

--- a/lib/chatmeter/version.rb
+++ b/lib/chatmeter/version.rb
@@ -1,3 +1,3 @@
 module Chatmeter
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/chatmeter/api/listings_spec.rb
+++ b/spec/chatmeter/api/listings_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Chatmeter::API do
+
+  context "Listings endpoing" do
+    let(:chatmeter) { Chatmeter::API.new(username: '123456@example.com', password: 'pw12345', mock: true) }
+    let(:params) { { locationId: "22121" } }
+
+		it "should return valid response for #competitors" do
+      listings = chatmeter.get_listings(params)
+      expect(listings).to have_key(:listings)
+      expect(listings[:listings]).to be_instance_of(Array)
+      expect(listings[:listings].count).to eq(2)
+    end
+
+  end
+end


### PR DESCRIPTION
This adds the path `/listings/` to chatmeter. To pull listings data about a location.