### PR TITLE
Defund chatmeter

### DIFF
--- a/lib/chatmeter/api.rb
+++ b/lib/chatmeter/api.rb
@@ -29,7 +29,6 @@ module Chatmeter
   class API
 
     HEADERS = {
-      'Accept-Encoding': 'gzip',
       'Accept':          'application/json',
       'Content-Type':    'application/json'
     }

--- a/lib/chatmeter/version.rb
+++ b/lib/chatmeter/version.rb
@@ -1,3 +1,3 @@
 module Chatmeter
-  VERSION = "1.3.6-1"
+  VERSION = "1.3.6"
 end

--- a/lib/chatmeter/version.rb
+++ b/lib/chatmeter/version.rb
@@ -1,3 +1,3 @@
 module Chatmeter
-  VERSION = "1.3.5"
+  VERSION = "1.3.6-1"
 end


### PR DESCRIPTION
remove the `'Accept-Encoding': 'gzip'` header from our API requests... because we can't actually handle gzipped response bodies.