### PR TITLE
Get and update methods for Email templates and Form

### DIFF
--- a/lib/chatmeter/api/email.rb
+++ b/lib/chatmeter/api/email.rb
@@ -10,5 +10,24 @@ module Chatmeter
         body:     params.to_json
       )
     end
+    
+    # GET /reviewBuilder/emailTemplate/{templateId}
+    def get_email_template_by_id(template_id)
+      request(
+        expects:  200,
+        method:   :get,
+        path:     "/reviewBuilder/emailTemplate/#{template_id}"
+      )
+    end
+
+    # POST /reviewBuilder/emailTemplate/{templateId}
+    def update_email_template(template_id, params)
+      request(
+        expects:  200,
+        method:   :post,
+        path:     "/reviewBuilder/emailTemplate/#{template_id}",
+        body:     params.to_json
+      )
+    end
   end
 end

--- a/lib/chatmeter/api/form.rb
+++ b/lib/chatmeter/api/form.rb
@@ -10,5 +10,24 @@ module Chatmeter
         body:     params.to_json
       )
     end
+
+    # GET /reviewBuilder/form/get/{formId}
+    def get_form_by_id(form_id)
+      request(
+        expects:  200,
+        method:   :get,
+        path:     "/reviewBuilder/form/get/#{form_id}"
+      )
+    end
+
+    # PUT /reviewBuilder/form/{formId}
+    def update_form(form_id, params)
+      request(
+        expects:  200,
+        method:   :put,
+        path:     "/reviewBuilder/form/#{form_id}",
+        body:     params.to_json
+      )
+    end
   end
 end

--- a/lib/chatmeter/api/mock/email.rb
+++ b/lib/chatmeter/api/mock/email.rb
@@ -35,6 +35,34 @@ module Chatmeter
           status: 201
         }
       end
+
+      # stub GET /reviewBuilder/emailTemplate/{templateId}
+      Excon.stub(expects: 200, method: :get, path: %r{^/v5/reviewBuilder/emailTemplate/([^/]+)$}) do |params|
+        request_params, mock_data = parse_stub_params(params)
+        {
+          body: email_response_body,
+          status: 200
+        }
+      end
+
+      # stub POST /reviewBuilder/emailTemplate/{templateId}
+      Excon.stub(expects: 200, method: :post, path: %r{^/v5/reviewBuilder/emailTemplate/([^/]+)$}) do |params|
+        params = JSON.parse(params[:body])
+
+        {
+          body: 
+          {  
+            "_id": "574e330cd4c6c9beb42c4ebd",
+            "name": "newEmailTemp",
+            "content": "<html>Html is here</html>",
+            "templateType": "email",
+            "accountId": "56a184a6d4c61f5267b3f386",
+            "deleted": false,
+            "dateAdded": 1464742668274 
+          },
+          status: 200
+        }
+      end
     end
   end
 end

--- a/lib/chatmeter/api/mock/email.rb
+++ b/lib/chatmeter/api/mock/email.rb
@@ -48,7 +48,6 @@ module Chatmeter
       # stub POST /reviewBuilder/emailTemplate/{templateId}
       Excon.stub(expects: 200, method: :post, path: %r{^/v5/reviewBuilder/emailTemplate/([^/]+)$}) do |params|
         params = JSON.parse(params[:body])
-
         {
           body: 
           {  

--- a/lib/chatmeter/api/mock/form.rb
+++ b/lib/chatmeter/api/mock/form.rb
@@ -31,6 +31,33 @@ module Chatmeter
           status: 201
         }
       end
+
+      # stub GET /reviewBuilder/form/get/{formId}
+      Excon.stub(expects: 200, method: :get, path: %r{^/v5/reviewBuilder/form/get/([^/]+)$}) do |params|
+        request_params, mock_data = parse_stub_params(params)
+        {
+          body: form_response_body,
+          status: 200
+        }
+      end
+
+      # stub PUT /reviewBuilder/form/{formId}
+      Excon.stub(expects: 200, method: :put, path: %r{^/v5/reviewBuilder/form/([^/]+)$}) do |params|
+        params = JSON.parse(params[:body])
+        {
+          body: 
+          {  
+            "_id": "574e182ed4c6c9beb42c4e14",
+            "name": "Updated Form",
+            "template":  "\n<!doctype html>\n<html>\n<body>New Form</body>\n</html>\n",
+            "thankYouTemplate": "\n<!doctype html>\n<html>\n<body>Thanks!</body>\n</html>\n",
+            "accountId": "56a184a6d4c61f5267b3f386",
+            "dateAdded": 1464735790275,
+            "deleted": false
+          },
+          status: 200
+        }
+      end
     end
   end
 end

--- a/spec/chatmeter/api/email_spec.rb
+++ b/spec/chatmeter/api/email_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Chatmeter::API do
       expect(email[:name]).to eq "GMB Reviews Email Template - Karl Hungus Productions"
     end
 
-    it "should return valid response for #update_account" do
+    it "should return valid response for #update_email_template" do
       email = chatmeter.update_email_template("5f4e59e15d962523aaf562a1", update_params)
 
       expect(email[:templateType]).to eq "email"

--- a/spec/chatmeter/api/email_spec.rb
+++ b/spec/chatmeter/api/email_spec.rb
@@ -4,13 +4,39 @@ RSpec.describe Chatmeter::API do
 
   context "Email Template endpoint" do
     let(:chatmeter) { Chatmeter::API.new(username: '123456@example.com', password: 'pw12345', mock: true) }
-
+    let(:update_params) do
+      {  
+        "_id": "574e330cd4c6c9beb42c4ebd",
+        "name": "newEmailTemp",
+        "content": "<html>Html is here</html>",
+        "templateType": "email",
+        "accountId": "56a184a6d4c61f5267b3f386",
+        "deleted": false,
+        "dateAdded": 1464742668274 
+      } 
+    end
     it "returns a valid response for #create_new_email_template" do
       email = chatmeter.create_new_email_template({})
 
       expect(email[:templateType]).to eq "email"
       expect(email[:accountId]).to eq "5a56bc4d01f0c9b909f3a82c"
       expect(email[:name]).to eq "GMB Reviews Email Template - Karl Hungus Productions"
+    end
+    
+    it "should return valid response for #get_email_template_by_id" do
+      email = chatmeter.get_email_template_by_id("1")
+      
+      expect(email[:templateType]).to eq "email"
+      expect(email[:accountId]).to eq "5a56bc4d01f0c9b909f3a82c"
+      expect(email[:name]).to eq "GMB Reviews Email Template - Karl Hungus Productions"
+    end
+
+    it "should return valid response for #update_account" do
+      email = chatmeter.update_email_template("5f4e59e15d962523aaf562a1", update_params)
+
+      expect(email[:templateType]).to eq "email"
+      expect(email[:accountId]).to eq "56a184a6d4c61f5267b3f386"
+      expect(email[:name]).to eq "newEmailTemp"
     end
   end
 end

--- a/spec/chatmeter/api/form_spec.rb
+++ b/spec/chatmeter/api/form_spec.rb
@@ -1,6 +1,17 @@
 require "spec_helper"
 
 RSpec.describe Chatmeter::API do
+  let(:update_params) do
+    { 
+      "_id": "574e182ed4c6c9beb42c4e14",
+      "name": "Updated Form",
+      "template":  "\n<!doctype html>\n<html>\n<body>New Form</body>\n</html>\n",
+      "thankYouTemplate": "\n<!doctype html>\n<html>\n<body>Thanks!</body>\n</html>\n",
+      "accountId": "56a184a6d4c61f5267b3f386",
+      "dateAdded": 1464735790275,
+      "deleted": false
+    }
+  end
 
   context "Forms endpoint" do
     let(:chatmeter) { Chatmeter::API.new(username: '123456@example.com', password: 'pw12345', mock: true) }
@@ -9,6 +20,22 @@ RSpec.describe Chatmeter::API do
       form = chatmeter.create_new_form({})
       expect(form[:template]).to eq "<html>Form Template</html>"
       expect(form[:_id]).to eq "5f4e59df4d43d55c51a742a4"
+    end
+        
+    it "should return valid response for #get_form_by_id" do
+      form = chatmeter.get_form_by_id("1")
+      
+      expect(form[:template]).to eq "<html>Form Template</html>"
+      expect(form[:_id]).to eq "5f4e59df4d43d55c51a742a4"
+      expect(form[:name]).to eq "GMB Reviews - Karl Hungus Productions"
+    end
+
+    it "should return valid response for #update_form" do
+      form = chatmeter.update_form("5f4e59e15d962523aaf562a1", update_params)
+
+      expect(form[:accountId]).to eq "56a184a6d4c61f5267b3f386"
+      expect(form[:_id]).to eq "574e182ed4c6c9beb42c4e14"
+      expect(form[:name]).to eq "Updated Form"
     end
   end
 end


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* Adds get and update methods for Email templates;
* Adds get and update methods for Form.

### Important Links:
[GET Email Template](https://apidocs.chatmeter.com/#get-email-template)
[UPDATE Email Template](https://apidocs.chatmeter.com/#update-email-template) 
[GET Form](https://apidocs.chatmeter.com/#get-form) 
[UPDATE Form](https://apidocs.chatmeter.com/#update-form) 

### Additional Information (Optional)
Before
![image](https://user-images.githubusercontent.com/47646621/129085016-c1242761-0d0a-4201-951d-92ac5b74533d.png)

After
![image](https://user-images.githubusercontent.com/47646621/129083724-f6c0fc5c-a985-43d4-901b-753f48bdb640.png)